### PR TITLE
feat(oss): sync editor/preview theme overlay + pane bg/text; lint sta…

### DIFF
--- a/src/components/CodeMirrorEditor.tsx
+++ b/src/components/CodeMirrorEditor.tsx
@@ -39,6 +39,12 @@ const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   const viewRef = useRef<EditorView | null>(null)
   const currentTheme = useRef<string>(theme)
   const isProgrammaticUpdate = useRef<boolean>(false)
+  const isDarkThemeName = (name: ThemeMode) => {
+    if (name === 'auto') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    return name.endsWith('-dark') || name === 'github-dark' || name === 'monokai'
+  }
 
   useEffect(() => {
     if (!editor.current) return
@@ -135,6 +141,28 @@ const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
     }
     
     extensions.push(getCodeMirrorTheme(theme))
+    // Keep editor bg/text synchronized with app theme variables
+    const dark = isDarkThemeName(theme)
+    extensions.push(
+      EditorView.theme(
+        {
+          '&': {
+            color: 'var(--text-color)',
+            backgroundColor: 'var(--bg-primary)',
+          },
+          '.cm-content': { caretColor: 'var(--text-color)' },
+          '.cm-activeLine': {
+            backgroundColor: 'color-mix(in oklab, var(--bg-tertiary) 40%, transparent)'
+          },
+          '.cm-gutters': {
+            backgroundColor: 'var(--bg-primary)',
+            color: 'var(--text-muted)',
+            border: 'none',
+          },
+        },
+        { dark }
+      )
+    )
 
     if (placeholder) {
       extensions.push(

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { AppSettings, ThemeMode } from '../types/settings'
 import ShortcutEditor from './ShortcutEditor'
 import './SettingsPanel.css'
-import { isProBuild } from '../pro'
+import { isProBuild } from '../utils/proFlags'
 
 interface SettingsPanelProps {
   isOpen: boolean

--- a/src/components/SplitPane.css
+++ b/src/components/SplitPane.css
@@ -10,6 +10,8 @@
   height: 100%;
   overflow: auto;
   box-sizing: border-box;
+  background-color: var(--bg-primary);
+  color: var(--text-color);
 }
 
 /* Add visual breathing room so scrollbars don't kiss borders */

--- a/src/utils/proFlags.ts
+++ b/src/utils/proFlags.ts
@@ -1,0 +1,12 @@
+export const isProBuild = (): boolean => {
+  try {
+    return Boolean(import.meta.env.MARKREVIEW_PRO)
+  } catch {
+    return false
+  }
+}
+
+export const isLicensed = async (): Promise<boolean> => false
+
+export const shouldEnablePro = async (): Promise<boolean> => false
+

--- a/src/utils/settingsPersist.ts
+++ b/src/utils/settingsPersist.ts
@@ -1,6 +1,6 @@
 import { AppSettings, DEFAULT_SETTINGS } from '../types/settings'
 import { logger } from './logger'
-import { isProBuild } from '../pro'
+import { isProBuild } from '../utils/proFlags'
 
 const SETTINGS_STORAGE_KEY = 'markreview-settings'
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
…bility in vite config; fix pro-flag imports for OSS\n\n- Add CSS-vars overlay in CodeMirrorEditor to unify bg/text\n- Add bg/text to SplitPane panes\n- Add /* eslint-env node */ to vite.config.ts\n- Add utils/proFlags.ts and point imports away from ../pro